### PR TITLE
[RFC] Use [GeneratedRegex] in UnicodeCharEscape

### DIFF
--- a/src/Onigwrap.Tests/Onigwrap.Tests.csproj
+++ b/src/Onigwrap.Tests/Onigwrap.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/src/Onigwrap/Onigwrap.csproj
+++ b/src/Onigwrap/Onigwrap.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>true</IsPackable>
-    <LangVersion>8.0</LangVersion>
     <Version>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../../VERSION"))</Version>
     <Description>Simple wrapper for Oniguruma.</Description>
     <Authors>Aikawa Yataro</Authors>

--- a/src/Onigwrap/UnicodeCharEscape.cs
+++ b/src/Onigwrap/UnicodeCharEscape.cs
@@ -1,20 +1,36 @@
+using System;
 using System.Text.RegularExpressions;
 
 namespace Onigwrap
 {
-    public class UnicodeCharEscape
+    public partial class UnicodeCharEscape
     {
-        private static Regex UNICODE_WITHOUT_BRACES_PATTERN = new Regex("\\\\x[A-Fa-f0-9]{2,8}");
+        private const string WithoutBracesPattern = "\\\\x[A-Fa-f0-9]{2,8}";
+        private static readonly Regex UNICODE_WITHOUT_BRACES_PATTERN =
+
+#if NET8_0_OR_GREATER
+            WithoutBracesRegex();
+
+        [GeneratedRegex(WithoutBracesPattern)]
+        private static partial Regex WithoutBracesRegex();
+#else
+            new Regex(WithoutBracesPattern);
+#endif
 
         public static string AddBracesToUnicodePatterns(string pattern)
         {
             return UNICODE_WITHOUT_BRACES_PATTERN.Replace(pattern, (m) =>
             {
-                string prefix = "\\x";
+                const string prefix = "\\x";
 
-                return string.Concat(
-                    prefix,
-                    "{", m.Value.Substring(prefix.Length), "}");
+                var substr =
+#if NET8_0_OR_GREATER
+                    m.Value.AsSpan(prefix.Length);
+#else
+                    m.Value.Substring(prefix.Length);
+#endif
+
+                return string.Concat(prefix, "{", substr, "}");
             });
         }
 


### PR DESCRIPTION
I'm not sure how much perf this might give you, but:

I was having a test of a few things, and wondered whether using ```GeneratedRegex``` here to build the regular expressions at compile time would be useful for performance or anything, but that does mean adding a .NET target on top of the .NET Standard one.

I added .NET 8.0, as that might also give the possibility of using [LibraryImport](https://learn.microsoft.com/en-gb/dotnet/standard/native-interop/pinvoke-source-generation) for calling the native oniguruma functions, and enabling all the trimming and AOT analyzers etc.

Any thoughts?