### PR TITLE
Add -headerpad_max_install_names to macOS linker flags

### DIFF
--- a/ci/build-onigwrap.osx.sh
+++ b/ci/build-onigwrap.osx.sh
@@ -4,6 +4,7 @@ set -e
 
 export CC="clang -target $_HOST"
 export CFLAGS="-O2 -s"
+export LDFLAGS="-Wl,-headerpad_max_install_names"
 
 mkdir -p buildprefix
 
@@ -16,4 +17,4 @@ make install
 
 popd
 
-$CC -dynamiclib onigwrap/onigwrap.c $CFLAGS -I./buildprefix/include -L./buildprefix/lib -lonig -o "$_LIBNAME"
+$CC -dynamiclib onigwrap/onigwrap.c $CFLAGS $LDFLAGS -I./buildprefix/include -L./buildprefix/lib -lonig -o "$_LIBNAME"


### PR DESCRIPTION
Without `-Wl,-headerpad_max_install_names`, the macOS dylib is built with zero header padding. When downstream build tooling (e.g. .NET/Mono app bundling) runs `install_name_tool` to rewrite the install name and add rpaths, the new load commands are longer than the original and there is no space left in the Mach-O header to fit them, resulting in:

```
install_name_tool: changing install names or rpaths can't be redone for: libonigwrap.dylib
(for architecture x86_64) because larger updated load commands do not fit
(the program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
```

This was not an issue with the previous universal binary build since fat binaries naturally carry more header space. The switch to single-architecture builds in the previous commit exposed this.

Adding `-Wl,-headerpad_max_install_names` to `LDFLAGS` (and passing `$LDFLAGS` through to the final link step) reserves enough header space for any realistic install name path, resolving the error.